### PR TITLE
Fix for unicode characters in MangaReader chapter names

### DIFF
--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -187,12 +187,12 @@ class SiteParserBase:
 			else:	
 				manga_chapter_prefix = zeroFillStr(fixFormatting(self.chapters[current_chapter][2], self.spaceToken), 3)
 		else:
-			manga_chapter_prefix = fixFormatting(self.manga, self.spaceToken) + '.' +  self.site + '.' + zeroFillStr(fixFormatting(self.chapters[current_chapter][1], self.spaceToken), 3)
+			manga_chapter_prefix = fixFormatting(self.manga, self.spaceToken) + '.' +  self.site + '.' + zeroFillStr(fixFormatting(self.chapters[current_chapter][1].decode('utf-8'), self.spaceToken), 3)
 
 		
 		# we already have it
 		if os.path.exists(os.path.join(self.downloadPath, manga_chapter_prefix) + self.downloadFormat) and self.overwrite_FLAG == False:
-			print(self.chapters[current_chapter][1] + ' already downloaded, skipping to next chapter...')
+			print(self.chapters[current_chapter][1].decode('utf-8') + ' already downloaded, skipping to next chapter...')
 			return
 
 		SiteParserBase.DownloadChapterThread.acquireSemaphore()

--- a/src/parsers/mangareader.py
+++ b/src/parsers/mangareader.py
@@ -48,7 +48,7 @@ class MangaReader(SiteParserBase):
 			if (not self.auto):
 				print('(%i) %s' % (i + 1, self.chapters[i][1]))
 			else:
-				if (self.lastDownloaded == self.chapters[i][1]):
+				if (self.lastDownloaded == self.chapters[i][1].decode('utf-8')):
 					lowerRange = i + 1
 		
 		# this might need to be len(self.chapters) + 1, I'm unsure as to whether python adds +1 to i after the loop or not


### PR DESCRIPTION
I discovered that chapter 139 of Claymore
(http://www.mangareader.net/claymore) on MangaReader had a non-ascii
character in it.

I'm not a Python developer so I've just stumbled my way into this fix. I'm sure there is a better way to do it, but this seems to work well enough to allow downloading without errors.
