### PR TITLE
Fixed mangahere issue with out of order next chapter

### DIFF
--- a/src/parsers/mangahere.py
+++ b/src/parsers/mangahere.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 ####################
 
@@ -161,7 +162,7 @@ class MangaHere(SiteParserBase):
 			print("Validating chapter: %s" % self.chapters[upperRange - 1][0])
 		source = getSourceCode(self.chapters[upperRange - 1][0], self.proxy)
 
-		if ('not available yet' in source):
+		if ('not available yet' in source) or ('Sorry, the page you have requested can’t be found' in source):
 			# If the last chapter is not available remove it from the list
 			del self.chapters[upperRange - 1]
 			upperRange = upperRange - 1;


### PR DESCRIPTION
Fixed mangahere chapter listing by ensuring sorting of chapters. The name returned as the next chapter could be a previously uploaded one. i.e. 1-400 with next chapter being 240. This happened with Hajime no Ippo for example as the next chapter was pointing to 1000.5 instead of 1053.

Not sure if this is the best solution so feel free to pitch in if necessary
