### PR TITLE
Parsers/Base: Fix crash dealing with unicode characters

### DIFF
--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -187,7 +187,7 @@ class SiteParserBase:
 			else:	
 				manga_chapter_prefix = zeroFillStr(fixFormatting(self.chapters[current_chapter][2], self.spaceToken), 3)
 		else:
-			manga_chapter_prefix = fixFormatting(self.manga, self.spaceToken) + '.' +  self.site + '.' + zeroFillStr(fixFormatting(self.chapters[current_chapter][1].decode('utf-8'), self.spaceToken), 3)
+			manga_chapter_prefix = fixFormatting(self.manga, self.spaceToken) + '.' +  self.site + '.' + zeroFillStr(fixFormatting(self.chapters[current_chapter][1], self.spaceToken), 3)
 
 		
 		# we already have it


### PR DESCRIPTION
Fixes a crash that was caused when downloading chapter 92 of Genshiken Nidaime from Batoto.

http://bato.to/comic/_/comics/genshiken-nidaime-the-society-for-the-study-of-modern-visual-culture-ii-r962