### PR TITLE
Updated required Python version in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ of over 10,000 mangas. Downloads into .cbz format, can optionally download into 
 
 ## Dependencies
 
-Python 2.6+, including 3.x
+Python 2.7+, including 3.x
 
 PIL if using Kindle conversion.
 

--- a/readme.md
+++ b/readme.md
@@ -13,14 +13,9 @@ of over 10,000 mangas. Downloads into .cbz format, can optionally download into 
 
 ## Dependencies
 
-Python 2.7+, including 3.x
+Python 2.7
 
 PIL if using Kindle conversion.
-
-How to backport to:
-
-  - 2.5 - change the exception-handling code and use `StringIO` instead of `io` module
-  - 2.4 - removing parentheses after class declarations
 
 ## Usage
 


### PR DESCRIPTION
It seems like the code changed quite a bit and it no longer works with Python 2.6 or 3.x. It doesn't look like 3.x support is a priority right now, so the readme should reflect this.