### PR TITLE
ignore utf-8 characters in manga titles for creating filenames

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -37,7 +37,7 @@ def fixFormatting(s, spaceToken):
 	"""
 	Special character fix for filesystem paths.
 	"""
-	
+	s = s.decode('utf-8').encode('ascii', 'ignore')
 	for i in string.punctuation:
 		if(i != '-' and i != spaceToken):
 			s = s.replace(i, '')


### PR DESCRIPTION
Some manga chapter titles have utf-8 characters in names, which are causing crashes due to unicode decode errors. Since punctuation is ignored anyway, utf-8 characters like smart quotes can also be ignored.

Quick fix for a crash I just noticed.