### PR TITLE
Added error handling for no chapters being found

### DIFF
--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -49,6 +49,15 @@ class SiteParserBase:
 
 		def __str__(self):
 			return self.errorMsg
+
+	# Manga was found, but no chapters were found to download
+	class NoChaptersFound(Exception):
+		
+		def __init__(self, errorMsg=''):
+			self.errorMsg = 'No chapters found. %s' % errorMsg
+		
+		def __str__(self):
+			return self.errorMsg
 		
 #####
 

--- a/src/parsers/batoto.py
+++ b/src/parsers/batoto.py
@@ -62,7 +62,10 @@ class Batoto(SiteParserBase):
         mname = [i for i in seriesl if i[0] == manga][0][1]
         s = getSourceCode(manga, self.proxy)
         soup = BeautifulSoup(s)
-        t = soup.find("table", class_="chapters_list").tbody
+        t = soup.find("table", class_="chapters_list")
+        if not t:
+        	raise self.NoChaptersFound
+        t = t.tbody
         cl = t.find_all("tr", class_="lang_English")
         self.chapters = [[]]
         cnum = self.chapters[0]


### PR DESCRIPTION
When you select a manga on Batoto, if there are no chapters available on the page, you get a no attribute error from BeautifulSoup. I added an exception called NoChaptersFound, and added handling for Batoto.