### PR TITLE
Using manga_downloader on Windows downloads corrupted images

### DIFF
--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -189,7 +189,7 @@ class SiteParserBase:
 				contentLength = int(responseInfo["Content-Length"])
 
 				temp_path = os.path.join(self.tempFolder, manga_chapter_prefix + '_' + str(page).zfill(3))
-				f = open(temp_path, 'w')
+				f = open(temp_path, 'wb')
 
 				f.write(response.read())
 				response.close()


### PR DESCRIPTION
You can reproduce this with any combination of options, sites and mangas. It would appear that this issue doesn't happen in Linux.

This is most likely happening because on line 192 of base.py the temp download location is not being opened in binary mode:

`f = open(temp_path, 'w')`

According to the [official Python2 documentation for the open function](https://docs.python.org/2/library/functions.html#open):

> Append 'b' to the mode to open the file in binary mode, on systems that differentiate between binary and text files; on systems that don’t have this distinction, adding the 'b' has no effect.

Windows does make this distinction.

Below is an example of this behavior. This is page 1 of Bleach 113 downloaded from MangaPanda: 
![bleach 113_001](https://cloud.githubusercontent.com/assets/817475/19097509/57198d94-8a73-11e6-95a2-c8a8bc5a4bad.jpeg)