### PR TITLE
Adding a build tankoubon (volume) option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,14 @@ The directory containing the images to convert when `convertDirectory` is specif
 The directory to store the converted Images. Omitting this option defaults to
 `DOWNLOAD_PATH/Pictures`.
 
+> `-k <number of chapters in tankoubon>, --tankoubon=<number of chapters in tankoubon>`
+
+Allows you to build a tankoubon (a volume file with multiple chapters in it) and specify how many chapters you want in each of them. Defaults to: 1, which means no tankoubon will be created.
+
+> `--cleanChapters`
+
+If -k is specified, this will remove the individual chapter files after building the tankoubon. It has no effect if -k is not specified. Omitting this option defaults to: False.
+
 ### Usage
 
 > `manga.py -d "C:\Documents and Settings\admin\Documents\Manga\" -z Bleach`

--- a/src/manga.py
+++ b/src/manga.py
@@ -90,7 +90,8 @@ def main():
 				useShortName = False,
 				spaceToken = '.',
 				proxy = None,
-				siteSelect = 0
+				siteSelect = 0,
+				chaptersInTankoubon = 1
 				)
 
 	parser.add_option(	'--all',
@@ -169,6 +170,10 @@ def main():
 	parser.add_option( 	'-s', '--site',
 				dest = 'siteSelect',
 				help = 'Specifies the site to download from.'				)
+	
+	parser.add_option('-k', '--tankoubon',
+					dest='chaptersInTankoubon',
+					help="Allows you to specify how many chapters you want in each tankoubon. Defaults to: %default.")
 
 	(options, args) = parser.parse_args()
 
@@ -184,6 +189,18 @@ def main():
 
 	if (options.maxChapterThreads <= 0):
 		options.maxChapterThreads = 2;
+		
+	# Check and sanitize the chaptersInTankoubon option
+	try:
+		options.chaptersInTankoubon = int(options.chaptersInTankoubon)
+	except:
+		options.chaptersInTankoubon = 1
+	
+	if (options.chaptersInTankoubon <= 0):
+		options.chaptersInTankoubon = 1
+	
+	options.shouldBuildTankoubon = True if options.chaptersInTankoubon > 1 else False
+	
 
 	if(len(args) == 0 and ( not (options.convert_Directory or options.xmlfile_path != None) )):
 		parser.error('Manga not specified.')

--- a/src/manga.py
+++ b/src/manga.py
@@ -91,7 +91,8 @@ def main():
 				spaceToken = '.',
 				proxy = None,
 				siteSelect = 0,
-				chaptersInTankoubon = 1
+				chaptersInTankoubon = 1,
+				cleanChaptersAfterBuildingTankoubon = False
 				)
 
 	parser.add_option(	'--all',
@@ -172,8 +173,14 @@ def main():
 				help = 'Specifies the site to download from.'				)
 	
 	parser.add_option('-k', '--tankoubon',
+					type = int,
 					dest='chaptersInTankoubon',
 					help="Allows you to specify how many chapters you want in each tankoubon. Defaults to: %default.")
+	
+	parser.add_option('--cleanChapters',
+					action = "store_true",
+					dest='cleanChaptersAfterBuildingTankoubon',
+					help="If -k is specified, this will remove the individual chapter files after building the tankoubon. It has no effect if -k is not specified. Defaults to: %default.")
 
 	(options, args) = parser.parse_args()
 
@@ -190,12 +197,7 @@ def main():
 	if (options.maxChapterThreads <= 0):
 		options.maxChapterThreads = 2;
 		
-	# Check and sanitize the chaptersInTankoubon option
-	try:
-		options.chaptersInTankoubon = int(options.chaptersInTankoubon)
-	except:
-		options.chaptersInTankoubon = 1
-	
+	# Check the chaptersInTankoubon option
 	if (options.chaptersInTankoubon <= 0):
 		options.chaptersInTankoubon = 1
 	

--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -11,7 +11,7 @@ import threading
 import time
 import urllib2
 import zipfile
-from tankoubonBuilder.tankoubon import Tankoubon
+from tankoubonBuilder.tankoubon import * 
 
 #####################
 
@@ -464,7 +464,7 @@ class SiteParserBase:
 					convertFile.convert(self.outputMgr, compressedFile, self.outputDir, self.device, self.verbose_FLAG)
 	
 	def buildTankoubon(self, downloadedChaptersFilenames, chaptersInTankoubon):
-		print("Building a tankoubon!")
+		print("Building tankoubon!")
 		# First we need to get all indexes in the dictionary and order them
 		#  before we think of getting the locations
 		tankoubonsToCreate = []
@@ -478,14 +478,14 @@ class SiteParserBase:
 		"""
 		tankoubonVolume = 1
 		while (orderedChaptersNames): # This is, while we have something in the list
-			print("Tankoubon number: %s" % str(tankoubonVolume))
 			tankoubonsToCreate.append(
 				Tankoubon(self.manga,
 						orderedChaptersNames[:chaptersInTankoubon],
-						self.downloadedChaptersFilenames, tankoubonVolume)
+						self.downloadedChaptersFilenames,
+						tankoubonVolume,
+						self.downloadFormat)
 				)
 			del orderedChaptersNames[:chaptersInTankoubon]
 			tankoubonVolume += 1
 				
-		raise NotImplementedError("We'll implement this later!")
-	
+		createTankoubonFiles(tankoubonsToCreate, self)

--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -427,7 +427,7 @@ class SiteParserBase:
 				isAllPassed = False
 		
 		if (isAllPassed and self.shouldBuildTankoubon):
-			self.buildTankoubon()
+			self.buildTankoubon(self.downloadedChaptersFilenames, self.chaptersInTankoubon)
 		
 		return isAllPassed
 
@@ -462,7 +462,26 @@ class SiteParserBase:
 				if (compressedFile != None and self.outputDir != None):
 					convertFile.convert(self.outputMgr, compressedFile, self.outputDir, self.device, self.verbose_FLAG)
 	
-	def buildTankoubon(self):
+	def buildTankoubon(self, downloadedChaptersFilenames, chaptersInTankoubon):
 		print("Building a tankoubon!")
+		# First we need to get all indexes in the dictionary and order them
+		#  before we think of getting the locations
+		volumesWithChapters = []
+		orderedChaptersNames = list(downloadedChaptersFilenames.keys())
+		orderedChaptersNames.sort()		
+		
+		""" 
+		    Now that we have the indexes ordered, let's build a blueprint of what
+		     chapters should go into each volume, we can further improve on this
+		     and use it in the future to feed the list of volumes into threads!
+		"""
+		tankoubonVolume = 1
+		while (orderedChaptersNames): # This is, while we have something in the list
+			print("Tankoubon number: %s" % str(tankoubonVolume))
+			volumesWithChapters.append(orderedChaptersNames[:chaptersInTankoubon])
+			del orderedChaptersNames[:chaptersInTankoubon]
+			tankoubonVolume += 1
+		print(volumesWithChapters)
+				
 		raise NotImplementedError("We'll implement this later!")
 	

--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -11,6 +11,7 @@ import threading
 import time
 import urllib2
 import zipfile
+from tankoubonBuilder.tankoubon import Tankoubon
 
 #####################
 
@@ -466,7 +467,7 @@ class SiteParserBase:
 		print("Building a tankoubon!")
 		# First we need to get all indexes in the dictionary and order them
 		#  before we think of getting the locations
-		volumesWithChapters = []
+		tankoubonsToCreate = []
 		orderedChaptersNames = list(downloadedChaptersFilenames.keys())
 		orderedChaptersNames.sort()		
 		
@@ -478,10 +479,13 @@ class SiteParserBase:
 		tankoubonVolume = 1
 		while (orderedChaptersNames): # This is, while we have something in the list
 			print("Tankoubon number: %s" % str(tankoubonVolume))
-			volumesWithChapters.append(orderedChaptersNames[:chaptersInTankoubon])
+			tankoubonsToCreate.append(
+				Tankoubon(self.manga,
+						orderedChaptersNames[:chaptersInTankoubon],
+						self.downloadedChaptersFilenames, tankoubonVolume)
+				)
 			del orderedChaptersNames[:chaptersInTankoubon]
 			tankoubonVolume += 1
-		print(volumesWithChapters)
 				
 		raise NotImplementedError("We'll implement this later!")
 	

--- a/src/tankoubonBuilder/tankoubon.py
+++ b/src/tankoubonBuilder/tankoubon.py
@@ -58,13 +58,17 @@ def createTankoubonFiles( tankoubonsToCreate, siteParser ):
 			for chapterName in t.chapters:
 				#  write every chapter file to the Tankoubon Zip file
 				#  close chapter
-				with zipfile.ZipFile( t.chaptersLocation.get( chapterName ), "r" ) as chapZ:
+				chapterLocation =  t.chaptersLocation.get( chapterName )
+				with zipfile.ZipFile( chapterLocation, "r" ) as chapZ:
 					imageNamelist = [( s, chapZ.read( s ) ) for s in chapZ.namelist()]
 					
 					for image in imageNamelist:
 						filename = image[0]
 						actualFile = image[1]
 						tankZ.writestr( filename, actualFile )
+						
+				if (siteParser.cleanChaptersAfterBuildingTankoubon):
+					os.remove(chapterLocation)
 		
 		# Move Zip file to DownloadLocation specified
 		if ( siteParser.overwrite_FLAG == True ):

--- a/src/tankoubonBuilder/tankoubon.py
+++ b/src/tankoubonBuilder/tankoubon.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
+import os
 import re
-
+import shutil
+import zipfile
+from fileinput import filename
 
 class Tankoubon:
 	'''
@@ -9,8 +12,8 @@ class Tankoubon:
 	'''
 
 
-	def __init__(self, manga = None, chapters = [], chaptersLocation = {}, 
-				volumeNumber = 1):
+	def __init__( self, manga = None, chapters = [], chaptersLocation = {},
+				volumeNumber = 1, fileFormat = ".cbz" ):
 		'''
 		Constructor
 		'''
@@ -18,26 +21,57 @@ class Tankoubon:
 		self.chapters = chapters
 		self.chaptersLocation = chaptersLocation
 		self.volumeNumber = volumeNumber
-		self.volumeName = self.buildVolumeName(self.manga, self.chapters,
-											 self.volumeNumber)
+		self.volumeName = self.buildVolumeName( self.manga, self.chapters,
+											 self.volumeNumber )
+		self.fileFormat = fileFormat
 		
-	def buildVolumeName(self, manga, chapters, volumeNumber):
+	def buildVolumeName( self, manga, chapters, volumeNumber ):
 		volumeName = None
 		
-		if(manga):
-			volumeName = str(manga)
+		if( manga ):
+			volumeName = str( manga )
 		else:
 			volumeName = ""
 			
-		if(volumeNumber):
-			volumeName += ".Vol " + str(volumeNumber)
+		if( volumeNumber ):
+			volumeName += ".Vol " + str( volumeNumber )
 			
-		if(chapters):
-			non_numbers = re.compile(r'[^\d]+')
-			numberOfChapters = len(chapters)
-			volumeName += ".Ch" + non_numbers.sub("", str(chapters[0]))
+		if( chapters ):
+			non_numbers = re.compile( r'[^\d]+' )
+			numberOfChapters = len( chapters )
+			volumeName += ".Ch" + non_numbers.sub( "", str( chapters[0] ) )
 			
-			if(numberOfChapters > 1):
-				volumeName += " - " + non_numbers.sub("", str(chapters[numberOfChapters - 1]))
+			if( numberOfChapters > 1 ):
+				volumeName += " - " + non_numbers.sub( "", str( chapters[numberOfChapters - 1] ) )
 			
 		return volumeName
+
+def createTankoubonFiles( tankoubonsToCreate, siteParser ):
+	for t in tankoubonsToCreate:
+		print( "Creating Tankoubon %s ..." % t.volumeNumber )
+		# Create temp folder
+		filePath = os.path.join( siteParser.tempFolder, t.volumeName ) + t.fileFormat
+		
+		# Create Zip file and be ready to put files in it
+		with zipfile.ZipFile( filePath, 'w' ) as tankZ:
+			# Loop through the chapters
+			for chapterName in t.chapters:
+				#  write every chapter file to the Tankoubon Zip file
+				#  close chapter
+				with zipfile.ZipFile( t.chaptersLocation.get( chapterName ), "r" ) as chapZ:
+					imageNamelist = [( s, chapZ.read( s ) ) for s in chapZ.namelist()]
+					
+					for image in imageNamelist:
+						filename = image[0]
+						actualFile = image[1]
+						tankZ.writestr( filename, actualFile )
+		
+		# Move Zip file to DownloadLocation specified
+		if ( siteParser.overwrite_FLAG == True ):
+			priorPath = os.path.join( siteParser.downloadPath, t.volumeName ) + t.fileFormat
+			if ( os.path.exists( priorPath ) ):
+				os.remove( priorPath )
+		
+		shutil.move( filePath, siteParser.downloadPath )
+	
+	print( "Finished building tankoubon!" )

--- a/src/tankoubonBuilder/tankoubon.py
+++ b/src/tankoubonBuilder/tankoubon.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import re
+
+
+class Tankoubon:
+	'''
+	classdocs
+	'''
+
+
+	def __init__(self, manga = None, chapters = [], chaptersLocation = {}, 
+				volumeNumber = 1):
+		'''
+		Constructor
+		'''
+		self.manga = manga
+		self.chapters = chapters
+		self.chaptersLocation = chaptersLocation
+		self.volumeNumber = volumeNumber
+		self.volumeName = self.buildVolumeName(self.manga, self.chapters,
+											 self.volumeNumber)
+		
+	def buildVolumeName(self, manga, chapters, volumeNumber):
+		volumeName = None
+		
+		if(manga):
+			volumeName = str(manga)
+		else:
+			volumeName = ""
+			
+		if(volumeNumber):
+			volumeName += ".Vol " + str(volumeNumber)
+			
+		if(chapters):
+			non_numbers = re.compile(r'[^\d]+')
+			numberOfChapters = len(chapters)
+			volumeName += ".Ch" + non_numbers.sub("", str(chapters[0]))
+			
+			if(numberOfChapters > 1):
+				volumeName += " - " + non_numbers.sub("", str(chapters[numberOfChapters - 1]))
+			
+		return volumeName


### PR DESCRIPTION
Implementing the feature request on #84

What if we could group our chapters in a neatly ordered [tankoubon](https://en.wikipedia.org/wiki/Tank%C5%8Dbon)? Like the ones you can get at any book store. You could then have a volume with 'n' number of chapters in it. It'd be easier to read in your favorite comic reader.

You should be able to control how many chapters you want in a given volume and have the option to optionally remove the individual chapter files once you are done compiling them into it.

This Pull Request adds two new options along with the appropriate documentation in the readme.md:

> `-k <number of chapters in tankoubon>, --tankoubon=<number of chapters in tankoubon>`

Allows you to build a tankoubon (a volume file with multiple chapters in it) and specify how many chapters you want in each of them. Defaults to: 1, which means no tankoubon will be created.

> `--cleanChapters`

If -k is specified, this will remove the individual chapter files after building the tankoubon. It has no effect if -k is not specified. Omitting this option defaults to: False.