### PR TITLE
Fix #82: Avoid silencing underlying exceptions in DownloadChapterThread.run

### DIFF
--- a/src/parsers/base.py
+++ b/src/parsers/base.py
@@ -393,7 +393,7 @@ class SiteParserBase:
 		def run (self):
 			try:
 				self.siteParser.processChapter(self, self.chapter)	
-			except Exception as exception:
+			except Exception:
 				# Assume semaphore has not been release
 				# This assumption could be faulty if the error was thrown in the compression function
 				# The worst case is that releasing the semaphore would allow one more thread to 
@@ -402,7 +402,8 @@ class SiteParserBase:
 				# If the semaphore was not released before the exception, it could cause deadlock
 				chapterThreadSemaphore.release()
 				self.isThreadFailed = True
-				raise FatalError("Thread crashed while downloading chapter: %s" % str(exception))
+				print("Thread crashed while downloading chapter: %s - %s" % (self.siteParser.manga, str(self.chapter)))
+				raise
 	
 	def download(self):
 		threadPool = []


### PR DESCRIPTION
Fixes #82 

As we were discussing on the issue, this commit lets us keep any underlying exception raised in the parsers.base.SiteParserBase.processChapter method. Hopefully this will help troubleshoot issues like #81.

I checked to see if anywhere in the code a FatalError was expected from the DownloadChapterThread.run but it's doesn't seem to be the case; I went ahead and just re-raised the original exception after taking care of the clean up operations.